### PR TITLE
Add dev quick help and frontend build command

### DIFF
--- a/Makefile.development
+++ b/Makefile.development
@@ -110,9 +110,15 @@ dev-restart: ## Reiniciar servicios de desarrollo
 
 .PHONY: dev-rebuild
 dev-rebuild: ## Reconstruir imagen de desarrollo
-	@echo "$(BLUE)🏗️  Reconstruyendo imagen...$(NC)"
-	@docker-compose build --no-cache ai-service
-	@echo "$(GREEN)✓ Imagen reconstruida$(NC)"
+        @echo "$(BLUE)🏗️  Reconstruyendo imagen...$(NC)"
+        @docker-compose build --no-cache ai-service
+        @echo "$(GREEN)✓ Imagen reconstruida$(NC)"
+
+.PHONY: dev-build-frontend
+dev-build-frontend: ## Recompilar frontend en desarrollo
+        @echo "$(BLUE)🔧 Compilando frontend...$(NC)"
+        @cd frontend && npm run build
+        @echo "$(GREEN)✓ Frontend compilado$(NC)"
 
 # =============================================================================
 # 🟢 COMANDOS DE DESARROLLO - Authentication Management
@@ -326,9 +332,26 @@ dev-clean: ## Limpiar archivos temporales y cache
 
 .PHONY: dev-install
 dev-install: ## Instalar dependencias
-	@echo "$(BLUE)📦 Instalando dependencias...$(NC)"
-	@npm install
-	@echo "$(GREEN)✓ Dependencias instaladas$(NC)"
+        @echo "$(BLUE)📦 Instalando dependencias...$(NC)"
+        @npm install
+        @echo "$(GREEN)✓ Dependencias instaladas$(NC)"
+
+.PHONY: dev-911 811
+dev-911 811: ## 🆘 Guía rápida de comandos de desarrollo
+        @echo "$(BLUE)╔════════════════════════════════════════════════════╗$(NC)"
+        @echo "$(BLUE)║       COMANDOS CLAVE PARA DESARROLLO LOCAL       ║$(NC)"
+        @echo "$(BLUE)╚════════════════════════════════════════════════════╝$(NC)"
+        @echo ""
+        @echo "$(YELLOW)Acciones frecuentes:$(NC)"
+        @echo "  $(GREEN)make dev-up$(NC)             - Levantar servicios"
+        @echo "  $(GREEN)make dev-rebuild$(NC)        - Reconstruir imagen backend"
+        @echo "  $(GREEN)make dev-build-frontend$(NC) - Recompilar frontend"
+        @echo "  $(GREEN)make dev-status$(NC)         - Ver estado actual"
+        @echo "  $(GREEN)make dev-logs$(NC)           - Ver logs del servicio"
+        @echo "  $(GREEN)make dev-down$(NC)           - Detener todo"
+        @echo ""
+        @echo "$(YELLOW)Para ver todos los comandos:$(NC)"
+        @echo "  $(GREEN)make -f Makefile.development help$(NC)"
 
 # =============================================================================
 # Ayuda

--- a/README-MAKEFILES.md
+++ b/README-MAKEFILES.md
@@ -14,6 +14,8 @@ make help-all
 
 # 4. En caso de emergencia
 make 911
+# 5. Ayuda de desarrollo
+make 811
 ```
 
 ## 📁 Estructura
@@ -47,6 +49,7 @@ make dev                 # Estado local
 make dev-up              # Levantar servicios
 make dev-reset-db        # Reset BD local
 make dev-test            # Ejecutar tests
+make dev-build-frontend  # Recompilar frontend
 ```
 
 ### Multi-ambiente
@@ -66,6 +69,7 @@ make compare-all         # Todas las comparaciones
 ### Emergencia
 ```bash
 make 911                 # Guía de emergencia
+make 811                 # Ayuda de desarrollo
 make prod-emergency-stop # Detener todo
 make prod-rollback       # Rollback completo
 ```


### PR DESCRIPTION
## Summary
- add `dev-build-frontend` target for compiling the frontend
- add `dev-911`/`811` target with quick help for development
- document new commands in README-MAKEFILES

## Testing
- `npm test` *(fails: Jest and services errors)*

------
https://chatgpt.com/codex/tasks/task_e_68744e787418832596d53455b0dcd38f