### PR TITLE
Add GoCardless sandbox access token support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,7 @@ GO_REDIRECT_URI=https://your-domain.com/financial/callback
 # GoCardless Sandbox Configuration (Development Only)
 GO_SANDBOX_MODE=false
 GO_SANDBOX_TOKEN=SANDBOXFINANCE_SFIN0000
+GO_SANDBOX_ACCESS_TOKEN=
 
 # Dashboard Configuration
 DASHBOARD_URL=https://your-domain.com/dashboard

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ npm run dev
 ```bash
 # Activar modo sandbox en .env.local
 GO_SANDBOX_MODE=true
+GO_SANDBOX_ACCESS_TOKEN=your_sandbox_access_token
 
 # Iniciar setup con banco mock
 curl -X POST http://localhost:3000/api/financial/setup-sandbox

--- a/docs/SANDBOX_TESTING.md
+++ b/docs/SANDBOX_TESTING.md
@@ -24,6 +24,7 @@ Set the following environment variables in your `.env.local`:
 # Enable sandbox mode
 GO_SANDBOX_MODE=true
 GO_SANDBOX_TOKEN=SANDBOXFINANCE_SFIN0000
+GO_SANDBOX_ACCESS_TOKEN=
 
 # Your regular GoCardless credentials still required
 GO_SECRET_ID=your_secret_id

--- a/scripts/migrate-env-to-db.js
+++ b/scripts/migrate-env-to-db.js
@@ -72,7 +72,14 @@ const migrationConfigs = [
     description: 'GoCardless Sandbox Institution Token',
     encrypt: false
   },
-  
+  {
+    envKey: 'GO_SANDBOX_ACCESS_TOKEN',
+    integrationType: 'gocardless',
+    configKey: 'sandbox_access_token',
+    description: 'GoCardless Sandbox Access Token',
+    encrypt: false
+  },
+
   // OpenAI
   {
     envKey: 'OPENAI_API_KEY',

--- a/scripts/migrate-env-to-db.ts
+++ b/scripts/migrate-env-to-db.ts
@@ -82,6 +82,13 @@ const migrationConfigs: MigrationConfig[] = [
     encrypt: false
   },
   {
+    envKey: 'GO_SANDBOX_ACCESS_TOKEN',
+    integrationType: 'gocardless',
+    configKey: 'sandbox_access_token',
+    description: 'GoCardless Sandbox Access Token',
+    encrypt: false
+  },
+  {
     envKey: 'GO_BASE_URL',
     integrationType: 'gocardless',
     configKey: 'base_url',

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,7 +45,8 @@ export const config = {
     redirectUri: process.env.GO_REDIRECT_URI || 'https://localhost:3000/financial/callback',
     sandboxMode: process.env.NODE_ENV === 'development' && process.env.GO_SANDBOX_MODE === 'true',
     sandboxToken: process.env.GO_SANDBOX_TOKEN || 'SANDBOXFINANCE_SFIN0000',
-    baseUrl: process.env.NODE_ENV === 'development' && process.env.GO_SANDBOX_MODE === 'true' 
+    sandboxAccessToken: process.env.GO_SANDBOX_ACCESS_TOKEN,
+    baseUrl: process.env.NODE_ENV === 'development' && process.env.GO_SANDBOX_MODE === 'true'
       ? 'https://bankaccountdata.gocardless.com/api/v2'
       : 'https://bankaccountdata.gocardless.com/api/v2'
   }

--- a/src/services/financial/gocardless.service.ts
+++ b/src/services/financial/gocardless.service.ts
@@ -111,17 +111,31 @@ export class GoCardlessService {
 
   async authenticate(): Promise<string> {
     try {
+      if (this.isSandboxMode) {
+        const sandboxToken = await integrationConfigService.getConfig({
+          integrationType: 'gocardless',
+          configKey: 'sandbox_access_token'
+        });
+
+        if (sandboxToken) {
+          this.accessToken = sandboxToken;
+          this.tokenExpiresAt = new Date(Date.now() + 23 * 60 * 60 * 1000);
+          logger.info('Using provided sandbox access token');
+          return this.accessToken;
+        }
+      }
+
       // Get credentials from integration config only
       const secretId = await integrationConfigService.getConfig({
         integrationType: 'gocardless',
         configKey: 'secret_id'
       });
-      
+
       const secretKey = await integrationConfigService.getConfig({
         integrationType: 'gocardless',
         configKey: 'secret_key'
       });
-      
+
       if (!secretId || !secretKey) {
         throw new Error('GoCardless credentials not configured in database');
       }
@@ -750,6 +764,16 @@ export class GoCardlessService {
 
   async hasCredentials(): Promise<boolean> {
     try {
+      if (this.isSandboxMode) {
+        const sandboxToken = await integrationConfigService.getConfig({
+          integrationType: 'gocardless',
+          configKey: 'sandbox_access_token'
+        });
+        if (sandboxToken) {
+          return true;
+        }
+      }
+
       const secretId = await integrationConfigService.getConfig({
         integrationType: 'gocardless',
         configKey: 'secret_id'
@@ -759,7 +783,7 @@ export class GoCardlessService {
         integrationType: 'gocardless',
         configKey: 'secret_key'
       });
-      
+
       return !!(secretId && secretKey);
     } catch (error) {
       logger.error('Failed to check credentials', error);


### PR DESCRIPTION
## Summary
- allow providing `GO_SANDBOX_ACCESS_TOKEN` in config
- migrate the new variable to the integration configuration table
- use the sandbox access token in `GoCardlessService.authenticate`
- document the new variable in README, docs, and example env file

## Testing
- `npm test` *(fails: various tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6875265a6cc48325a7e3d969fe8e5988